### PR TITLE
Add single quotes around ops-man glob.

### DIFF
--- a/workspace/pivnet-download-test/pipeline.yml
+++ b/workspace/pivnet-download-test/pipeline.yml
@@ -31,4 +31,4 @@ jobs:
     trigger: true
     params:
       globs:
-      - *-gcp-*.yml # This expression uniquely identifies the target in the file group
+      - '*-gcp-*.yml' # This expression uniquely identifies the target in the file group


### PR DESCRIPTION
Without quotes around the glob, fly returns the following error:

```  
   fly -t cc set-pipeline -n \
    -p pivnet-download-test \
    -c pivnet-download.yml \
    --var=pivnet_token=${PKS_PIVNET_UAA_REFRESH_TOKEN}

error: yaml: line 34: did not find expected alphabetic or numeric character
```